### PR TITLE
fix: use `pythia8-config` to get `cxxflags` and `ldflags`

### DIFF
--- a/Pythia8/Makefile
+++ b/Pythia8/Makefile
@@ -8,12 +8,12 @@ endif
 CXXFLAGS     = -std=c++11
 CXXFLAGS     += `root-config --cflags`
 CXXFLAGS     += `fastjet-config --cxxflags`
-CXXFLAGS     += -I$(PYTHIA8)/include
+CXXFLAGS     += `pythia8-config --cxxflags`
 
 LDFLAGS      = 
 LDFLAGS     += `root-config --libs`
 LDFLAGS     += `fastjet-config --libs --plugins`
-LDFLAGS     += -L$(PYTHIA8)/lib -lpythia8
+LDFLAGS     += `pythia8-config --ldflags`
 
 #all : PythiaHepMC
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes #2 by using `pythia8-config` instead of `$PYTHIA8` (which is non-standard).

Remaining issue: `HEPMC_DIR = $(EICDIRECTORY)`