### PR TITLE
fix: don't override -std=c++11 since root-config specifies it too

### DIFF
--- a/Pythia8/Makefile
+++ b/Pythia8/Makefile
@@ -5,7 +5,7 @@ else
 CXX          = c++
 endif
 
-CXXFLAGS     = -std=c++11
+CXXFLAGS     =
 CXXFLAGS     += `root-config --cflags`
 CXXFLAGS     += `fastjet-config --cxxflags`
 CXXFLAGS     += `pythia8-config --cxxflags`


### PR DESCRIPTION
### Briefly, what does this PR introduce?
ROOT states that dependent code is only supported if it uses the C++ standard that ROOT was compiled with. We should avoid overriding the `-std=c++XX` that is already included in `root-config --cflags` with a hardcoded std flag. (And neither `fastjet-config` nor `pythia8-config` specifies a std flag.)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
