### PR TITLE
feat: propagate beam configuration settings to HepMC run info

### DIFF
--- a/Pythia8/eicBeamShape.h
+++ b/Pythia8/eicBeamShape.h
@@ -24,6 +24,13 @@ class eicBeamShape : public BeamShape {
 
   void RotXY(double theta, double phi, double xin, double yin, double zin, double *xout, double *yout, double *zout);
 
+  // Getters for configuration parameters
+  int getDivAcc() const { return mDivAcc; }
+  double getIonBeamEnergy() const { return mIonBeamEnergy; }
+  double getLeptonBeamEnergy() const { return mLeptonBeamEnergy; }
+  double getXAngle() const { return mXAngle; }
+  double getXAngleY() const { return mXAngleY; }
+
  protected:
 
   int mDivAcc;


### PR DESCRIPTION
The afterburner uses ab_ prefixed metadata, but they may have different meaning. The current implementation stores values with eic_ prefix instead.