### PR TITLE
Updates4 may campaign

### DIFF
--- a/Pythia8/eicBeamShape.cxx
+++ b/Pythia8/eicBeamShape.cxx
@@ -18,27 +18,39 @@ eicBeamShape::eicBeamShape(int config, double ion, double lepton, double xAngle)
     mKill = 0;
 
     // Ensure Beam Energies Correspond to Those Presented in CDR
-    if(ion != 275.0 && ion != 110.0 && ion != 100.0 && ion != 41.0) 
+    if(ion != 275.0 && ion != 110.0 && ion != 100.0 && ion != 41.0 && ion != 250.0 && ion != 130.0) // Add 250.0 and 130.0 for early science (May 2026)
       {
 	cout << ion << " is not a valid Hadron Beam Energy!!" << endl;
 	cout << "Valid Energies are 275.0, 110.0, 100.0, and 41.0" << endl;
+	cout << "Valid Early Science Energies are 250.0 and 130.0" << endl;
 	cout << "Turning off all beam effects" << endl;
 	mKill = 1;
       }
-    if(lepton != 18.0 && lepton != 10.0 && lepton != 5.0) 
+    if(lepton != 18.0 && lepton != 10.0 && lepton != 9.0 && lepton != 5.0) 
       {
 	cout << lepton << " is not a valid Lepton Beam Energy!!" << endl;
 	cout << "Valid Energies are 18.0, 10.0, and 5.0" << endl;
+	cout << "Valid Energy includes 9.0" << endl; // Add 9.0 for early science (May 2026)
 	cout << "Turning off all beam effects" << endl;
 	mKill = 1;
       }
 
     // Ensure Beam Energy Combinations Correspond to Those Presented in CDR
-    if(ion == 275.0 && (lepton != 18.0 && lepton != 10.0))
+    if(ion == 275.0 && (lepton != 18.0 && lepton != 10.0 && lepton != 9.0))
       {
 	cout << lepton << "x" << ion << " is not a valid energy combination!!" << endl;
 	cout << "Valid (ep) Combinations are 18x275, 10x275, 10x100, 5x100, and 5x41" << endl;
 	cout << "Valid (eA) Combinations are 18x110, 10x110, 5x110, and 5x41" << endl;
+	cout << "Valid (early science) Combinations includes 9x275" << endl; // Add 9x275 for early science (May 2026)
+	cout << "Turning off all beam effects" << endl;
+	mKill = 1;
+      }
+    if(ion == 250.0 && lepton != 10.0) // Add Early Science Energy (May 2026)
+      {
+	cout << lepton << "x" << ion << " is not a valid energy combination!!" << endl;
+	cout << "Valid (ep) Combinations are 18x275, 10x275, 10x100, 5x100, and 5x41" << endl;
+	cout << "Valid (eA) Combinations are 18x110, 10x110, 5x110, and 5x41" << endl;
+	cout << "Valid (early science) Combinations are 10x250 and 10x130" << endl;
 	cout << "Turning off all beam effects" << endl;
 	mKill = 1;
       }
@@ -47,6 +59,15 @@ eicBeamShape::eicBeamShape(int config, double ion, double lepton, double xAngle)
 	cout << lepton << "x" << ion << " is not a valid energy combination!!" << endl;
 	cout << "Valid (ep) Combinations are 18x275, 10x275, 10x100, 5x100, and 5x41" << endl;
 	cout << "Valid (eA) Combinations are 18x110, 10x110, 5x110, and 5x41" << endl;
+	cout << "Turning off all beam effects" << endl;
+	mKill = 1;
+      }
+    if(ion == 130.0 && (lepton != 10.0 && lepton != 9.0)) // Add Early Science Energy (May 2026)
+      {
+	cout << lepton << "x" << ion << " is not a valid energy combination!!" << endl;
+	cout << "Valid (ep) Combinations are 18x275, 10x275, 10x100, 5x100, and 5x41" << endl;
+	cout << "Valid (eA) Combinations are 18x110, 10x110, 5x110, and 5x41" << endl;
+	cout << "Valid (early science) Combinations are 10x250, 10x130, 9x275, and 9x130" << endl;
 	cout << "Turning off all beam effects" << endl;
 	mKill = 1;
       }
@@ -96,12 +117,15 @@ void eicBeamShape::pick() {
       
       // Set different values depending on energy
       if(mIonBeamEnergy == 275.0) hadronBL = 60.0;
+      if(mIonBeamEnergy == 250.0) hadronBL = 60.0; // Copy 275 parameters to 250 for early science (May 2026)
       if(mIonBeamEnergy == 110.0) hadronBL = 70.0;
+      if(mIonBeamEnergy == 130.0) hadronBL = 70.0; // Copy 100 parameters to 130 for early science (May 2026)
       if(mIonBeamEnergy == 100.0) hadronBL = 70.0;
       if(mIonBeamEnergy == 41.0 && mDivAcc != 3) hadronBL = 75.0;
       if(mIonBeamEnergy == 41.0 && mDivAcc == 3) hadronBL = 116.0; // for eA
       if(mLeptonBeamEnergy == 18.0) leptonBL = 9.0;
       if(mLeptonBeamEnergy == 10.0) leptonBL = 7.0;
+      if(mLeptonBeamEnergy == 9.0)  leptonBL = 7.0; // Copy 10 to 9 for early science (May 2026)
       if(mLeptonBeamEnergy == 5.0)  leptonBL = 7.0;
       
       // Set particle positions
@@ -264,12 +288,17 @@ void eicBeamShape::pick() {
       double betaStarHad = 0.; // In horizontal direction
 
       if(mIonBeamEnergy == 275.0) betaCrabHad = 1300000.0;
+      if(mIonBeamEnergy == 250.0) betaCrabHad = 1300000.0; // Copy 275 to 250 for early science (May 2026)
       if(mIonBeamEnergy == 110.0) betaCrabHad = 500000.0; // Estimate
+      if(mIonBeamEnergy == 130.0) betaCrabHad = 500000.0; // Copy 100 to 130 for early science (May 2026)
       if(mIonBeamEnergy == 100.0) betaCrabHad = 500000.0;
       if(mIonBeamEnergy == 41.0)  betaCrabHad = 200000.0;
       if(mDivAcc == 1) // High Divergence Config - CDR Table 3.3
 	{
 	  if(mIonBeamEnergy == 275.0) betaStarHad = 800.0;
+	  if(mIonBeamEnergy == 250.0) betaStarHad = 800.0; // Copy 275 to 250 for early science (May 2026)
+	  if(mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 10.0) betaStarHad = 630.0; // Copy 10x100 to 10x130 for early science (May 2026)
+	  if(mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 9.0)  betaStarHad = 630.0; // Copy 10x100 to 9x130 for early science (May 2026)
 	  if(mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 10.0) betaStarHad = 630.0; // For root[s] = 63.2
 	  if(mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 5.0)  betaStarHad = 610.0; // For root[s] = 44.7
 	  if(mIonBeamEnergy == 41.0)  betaStarHad = 900.0;
@@ -278,6 +307,10 @@ void eicBeamShape::pick() {
 	{
 	  if(mIonBeamEnergy == 275.0 && mLeptonBeamEnergy == 18.0) betaStarHad = 4170.0; // For root[s] = 140.7
 	  if(mIonBeamEnergy == 275.0 && mLeptonBeamEnergy == 10.0) betaStarHad = 2650.0; // For root[s] = 104.9
+	  if(mIonBeamEnergy == 275.0 && mLeptonBeamEnergy == 9.0)  betaStarHad = 2650.0; // Copy 10x275 to 9x275 for early science (May 2026)
+	  if(mIonBeamEnergy == 250.0 && mLeptonBeamEnergy == 10.0) betaStarHad = 2650.0; // Copy 10x275 to 10x250 for early science (May 2026)
+	  if(mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 10.0) betaStarHad = 940.0; // Copy 10x100 to 10x130 for early science (May 2026)
+	  if(mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 9.0)  betaStarHad = 940.0; // Copy 10x100 to 9x130 for early science (May 2026)
 	  if(mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 10.0) betaStarHad = 940.0; // For root[s] = 63.2
 	  if(mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 5.0)  betaStarHad = 800.0; // For root[s] = 44.7
 	  if(mIonBeamEnergy == 41.0 && mLeptonBeamEnergy == 5.0)   betaStarHad = 900.0; // For root[s] = 28.6
@@ -292,11 +325,16 @@ void eicBeamShape::pick() {
       double betaStarLep = 0.;
       if(mLeptonBeamEnergy == 18.0) betaCrabLep = 150000.0;
       if(mLeptonBeamEnergy == 10.0) betaCrabLep = 150000.0;
+      if(mLeptonBeamEnergy == 9.0)  betaCrabLep = 150000.0;
       if(mLeptonBeamEnergy == 5.0)  betaCrabLep = 150000.0;
       if(mDivAcc == 1) // High Divergence Config - CDR Table 3.3
 	{
 	  if(mLeptonBeamEnergy == 18.0) betaStarLep = 590.0;
 	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 275.0) betaStarLep = 450.0; // For root[s] = 104.9
+	  if(mLeptonBeamEnergy == 9.0 && mIonBeamEnergy == 275.0)  betaStarLep = 450.0; // Copy 10x275 to 9x275 
+	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 250.0) betaStarLep = 450.0; // Copy 10x275 to 10x250 for early science (May 2026)
+	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 130.0) betaStarLep = 960.0; // Copy 10x100 to 10x130 for early science (May 2026)
+	  if(mLeptonBeamEnergy == 9.0 && mIonBeamEnergy == 130.0)  betaStarLep = 960.0; // Copy 10x100 to 9x130 for early science (May 2026)
 	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 100.0) betaStarLep = 960.0; // For root[s] = 63.2
 	  if(mLeptonBeamEnergy == 5.0 && mIonBeamEnergy == 100.0)  betaStarLep = 780.0; // For root[s] = 44.7
 	  if(mLeptonBeamEnergy == 5.0 && mIonBeamEnergy == 41.0)   betaStarLep = 1960.0; // For root[s] = 28.6
@@ -305,6 +343,10 @@ void eicBeamShape::pick() {
 	{
 	  if(mLeptonBeamEnergy == 18.0) betaStarLep = 3060.0;
 	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 275.0) betaStarLep = 1490.0; // For root[s] = 104.9
+	  if(mLeptonBeamEnergy == 9.0 && mIonBeamEnergy == 275.0)  betaStarLep = 1490.0; // Copy 10x275 to 9x275 for early science (May 2026)
+	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 250.0) betaStarLep = 1490.0; // Copy 10x275 to 10x250 for early science (May 2026)
+	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 130.0) betaStarLep = 1430.0; // Copy 10x100 to 10x130 for early science (May 2026)
+	  if(mLeptonBeamEnergy == 9.0 && mIonBeamEnergy == 130.0)  betaStarLep = 1430.0; // Copy 10x100 to 9x130 for early science (May 2026)
 	  if(mLeptonBeamEnergy == 10.0 && mIonBeamEnergy == 100.0) betaStarLep = 1430.0; // For root[s] = 63.2
 	  if(mLeptonBeamEnergy == 5.0 && mIonBeamEnergy == 100.0)  betaStarLep = 1030.0; // For root[s] = 44.7
 	  if(mLeptonBeamEnergy == 5.0 && mIonBeamEnergy == 41.0)   betaStarLep = 1960.0; // For root[s] = 28.6 
@@ -366,7 +408,7 @@ void eicBeamShape::pick() {
 	}
       if(mDivAcc == 3) localKill = 1;
     }
-  if(mIonBeamEnergy == 275.0 && mLeptonBeamEnergy == 10.0)
+  if((mIonBeamEnergy == 275.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 250.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 275.0 && mLeptonBeamEnergy == 9.0)) // Add 10x250 and 9x275 for early science (May 2026)
     {
       if(mDivAcc == 1)
 	{
@@ -426,7 +468,7 @@ void eicBeamShape::pick() {
 	  if(sigmaVertexX != 0.175 || sigmaVertexY != 0.011) localKill = 1;
 	}
     }
-  if(mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 10.0)
+  if((mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 9.0)) // Add 10x130 adn 9x130 for early science (May 2026)
     {
       if(mDivAcc == 1)
 	{

--- a/Pythia8/eicBeamShape.cxx
+++ b/Pythia8/eicBeamShape.cxx
@@ -468,7 +468,7 @@ void eicBeamShape::pick() {
 	  if(sigmaVertexX != 0.175 || sigmaVertexY != 0.011) localKill = 1;
 	}
     }
-  if((mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 9.0)) // Add 10x130 adn 9x130 for early science (May 2026)
+  if((mIonBeamEnergy == 100.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 10.0) || (mIonBeamEnergy == 130.0 && mLeptonBeamEnergy == 9.0)) // Add 10x130 and 9x130 for early science (May 2026)
     {
       if(mDivAcc == 1)
 	{

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x100_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x100_100to1000
@@ -56,9 +56,10 @@ TimeShower:QEDshowerByL = off
 !
 ! PhaseSpace:pTHatMin = 1.0
 ! PhaseSpace:pTHatMinDiverge = 0.5
-PhaseSpace:mHatMin = 1.0
-PhaseSpace:pTHatMinDiverge = force 0.45
-PhaseSpace:Q2Min = 10.0
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
 
 
 ! Hadronization and Radiation Settings

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x100_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x100_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 100
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.098
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x100_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x100_1to10
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x275 in High Divergence Mode
+! 10x100 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000
@@ -11,21 +11,21 @@ Beams:frameType = 2
 Beams:idA = 2212
 Beams:idB = 11
 
-Beams:eA = 275
+Beams:eA = 100
 Beams:eB = 10
 
 Beams:allowMomentumSpread = on
-Beams:sigmapxA = 0.000119
-Beams:sigmapyA = 0.000119
-Beams:sigmapzA = 0.00068
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
+Beams:sigmapzA = 0.00097
 
-Beams:sigmapxB = 0.000211
-Beams:sigmapyB = 0.000152
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
 Beams:sigmapzB = 0.00058
 
 Beams:allowVertexSpread = on
-Beams:sigmaVertexX = 0.067
-Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexX = 0.098
+Beams:sigmaVertexY = 0.008
 Beams:sigmaVertexZ = 0.0
 
 
@@ -56,9 +56,10 @@ TimeShower:QEDshowerByL = off
 !
 ! PhaseSpace:pTHatMin = 1.0
 ! PhaseSpace:pTHatMinDiverge = 0.5
-PhaseSpace:mHatMin = 1.0
-PhaseSpace:pTHatMinDiverge = force 0.45
-PhaseSpace:Q2Min = 10.0
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
 
 
 ! Hadronization and Radiation Settings

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_100to1000
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 130
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.098
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_100to1000
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x100 in High Divergence Mode
+! 10x130 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_10to100
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x100 in High Divergence Mode
+! 10x130 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 130
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.098
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_1to10
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 5x100 in High Divergence Mode
+! 10x100 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000
@@ -11,20 +11,20 @@ Beams:frameType = 2
 Beams:idA = 2212
 Beams:idB = 11
 
-Beams:eA = 100
-Beams:eB = 5
+Beams:eA = 130
+Beams:eB = 10
 
 Beams:allowMomentumSpread = on
-Beams:sigmapxA = 0.000206
-Beams:sigmapyA = 0.000206
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
 Beams:sigmapzA = 0.00097
 
-Beams:sigmapxB = 0.000160
-Beams:sigmapyB = 0.000160
-Beams:sigmapzB = 0.00068
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
+Beams:sigmapzB = 0.00058
 
 Beams:allowVertexSpread = on
-Beams:sigmaVertexX = 0.088
+Beams:sigmaVertexX = 0.098
 Beams:sigmaVertexY = 0.008
 Beams:sigmaVertexZ = 0.0
 
@@ -56,9 +56,10 @@ TimeShower:QEDshowerByL = off
 !
 ! PhaseSpace:pTHatMin = 1.0
 ! PhaseSpace:pTHatMinDiverge = 0.5
-PhaseSpace:mHatMin = 1.0
-PhaseSpace:pTHatMinDiverge = force 0.45
-PhaseSpace:Q2Min = 10.0
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
 
 
 ! Hadronization and Radiation Settings

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x130_1to10
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x100 in High Divergence Mode
+! 10x130 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_100to1000
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 250
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_100to1000
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x275 in High Divergence Mode
+! 10x250 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_10to100
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x275 in High Divergence Mode
+! 10x250 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 250
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_1to10
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 250
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x250_1to10
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x275 in High Divergence Mode
+! 10x250 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x275_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x275_100to1000
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x275_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x275_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x275_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_10x275_1to10
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 10
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_18x275_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_18x275_100to1000
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 5x41 in High Divergence Mode
+! 18x275 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000
@@ -11,21 +11,21 @@ Beams:frameType = 2
 Beams:idA = 2212
 Beams:idB = 11
 
-Beams:eA = 41
-Beams:eB = 5
+Beams:eA = 275
+Beams:eB = 18
 
 Beams:allowMomentumSpread = on
-Beams:sigmapxA = 0.000220
-Beams:sigmapyA = 0.000380
-Beams:sigmapzA = 0.00103
+Beams:sigmapxA = 0.000150
+Beams:sigmapyA = 0.000150
+Beams:sigmapzA = 0.00068
 
-Beams:sigmapxB = 0.000101
-Beams:sigmapyB = 0.000129
-Beams:sigmapzB = 0.00068
+Beams:sigmapxB = 0.000202
+Beams:sigmapyB = 0.000187
+Beams:sigmapzB = 0.00109
 
 Beams:allowVertexSpread = on
-Beams:sigmaVertexX = 0.140
-Beams:sigmaVertexY = 0.019
+Beams:sigmaVertexX = 0.084
+Beams:sigmaVertexY = 0.008
 Beams:sigmaVertexZ = 0.0
 
 
@@ -56,9 +56,10 @@ TimeShower:QEDshowerByL = off
 !
 ! PhaseSpace:pTHatMin = 1.0
 ! PhaseSpace:pTHatMinDiverge = 0.5
-PhaseSpace:mHatMin = 1.0
-PhaseSpace:pTHatMinDiverge = force 0.45
-PhaseSpace:Q2Min = 10.0
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
 
 
 ! Hadronization and Radiation Settings

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_18x275_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_18x275_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 18x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 18
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000150
+Beams:sigmapyA = 0.000150
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000202
+Beams:sigmapyB = 0.000187
+Beams:sigmapzB = 0.00109
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.084
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_18x275_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_18x275_1to10
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 18x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 18
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000150
+Beams:sigmapyA = 0.000150
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000202
+Beams:sigmapyB = 0.000187
+Beams:sigmapzB = 0.00109
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.084
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x100_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x100_100to1000
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 5x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 100
+Beams:eB = 5
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000206
+Beams:sigmapyA = 0.000206
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000160
+Beams:sigmapyB = 0.000160
+Beams:sigmapzB = 0.00068
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.088
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x100_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x100_10to100
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 18x275 in High Divergence Mode
+! 5x100 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000
@@ -11,20 +11,20 @@ Beams:frameType = 2
 Beams:idA = 2212
 Beams:idB = 11
 
-Beams:eA = 275
-Beams:eB = 18
+Beams:eA = 100
+Beams:eB = 5
 
 Beams:allowMomentumSpread = on
-Beams:sigmapxA = 0.000150
-Beams:sigmapyA = 0.000150
-Beams:sigmapzA = 0.00068
+Beams:sigmapxA = 0.000206
+Beams:sigmapyA = 0.000206
+Beams:sigmapzA = 0.00097
 
-Beams:sigmapxB = 0.000202
-Beams:sigmapyB = 0.000187
-Beams:sigmapzB = 0.00109
+Beams:sigmapxB = 0.000160
+Beams:sigmapyB = 0.000160
+Beams:sigmapzB = 0.00068
 
 Beams:allowVertexSpread = on
-Beams:sigmaVertexX = 0.084
+Beams:sigmaVertexX = 0.088
 Beams:sigmaVertexY = 0.008
 Beams:sigmaVertexZ = 0.0
 
@@ -56,9 +56,10 @@ TimeShower:QEDshowerByL = off
 !
 ! PhaseSpace:pTHatMin = 1.0
 ! PhaseSpace:pTHatMinDiverge = 0.5
-PhaseSpace:mHatMin = 1.0
-PhaseSpace:pTHatMinDiverge = force 0.45
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
 PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
 
 
 ! Hadronization and Radiation Settings

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x100_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x100_1to10
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 5x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 100
+Beams:eB = 5
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000206
+Beams:sigmapyA = 0.000206
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000160
+Beams:sigmapyB = 0.000160
+Beams:sigmapzB = 0.00068
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.088
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x41_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x41_100to1000
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 5x41 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 41
+Beams:eB = 5
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000380
+Beams:sigmapzA = 0.00103
+
+Beams:sigmapxB = 0.000101
+Beams:sigmapyB = 0.000129
+Beams:sigmapzB = 0.00068
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.140
+Beams:sigmaVertexY = 0.019
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x41_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x41_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 5x41 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 41
+Beams:eB = 5
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000380
+Beams:sigmapzA = 0.00103
+
+Beams:sigmapxB = 0.000101
+Beams:sigmapyB = 0.000129
+Beams:sigmapzB = 0.00068
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.140
+Beams:sigmaVertexY = 0.019
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x41_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_5x41_1to10
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 5x41 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 41
+Beams:eB = 5
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000380
+Beams:sigmapzA = 0.00103
+
+Beams:sigmapxB = 0.000101
+Beams:sigmapyB = 0.000129
+Beams:sigmapzB = 0.00068
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.140
+Beams:sigmaVertexY = 0.019
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_100to1000
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 130
+Beams:eB = 9
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.098
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_100to1000
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x100 in High Divergence Mode
+! 9x130 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 130
+Beams:eB = 9
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.098
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_10to100
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x100 in High Divergence Mode
+! 9x130 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_1to10
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x100 in High Divergence Mode
+! 9x130 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x130_1to10
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x100 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 130
+Beams:eB = 9
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000220
+Beams:sigmapyA = 0.000220
+Beams:sigmapzA = 0.00097
+
+Beams:sigmapxB = 0.000145
+Beams:sigmapyB = 0.000105
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.098
+Beams:sigmaVertexY = 0.008
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_100to1000
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x275 in High Divergence Mode
+! 9x275 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_100to1000
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_100to1000
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 9
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 100.0
+PhaseSpace:Q2Max = 1000.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_10to100
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 9
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 10.0
+PhaseSpace:Q2Max = 100.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_10to100
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_10to100
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x275 in High Divergence Mode
+! 9x275 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_1to10
@@ -1,5 +1,5 @@
 ! Steering file for LO DIS with realistic EIC beam parameters
-! 10x275 in High Divergence Mode
+! 9x275 in High Divergence Mode
 ! See CDR Table 3.3
 
 Main:numberOfEvents = 1000000

--- a/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_1to10
+++ b/Pythia8/steerFiles/dis_eicBeam_hiDiv_9x275_1to10
@@ -1,0 +1,86 @@
+! Steering file for LO DIS with realistic EIC beam parameters
+! 10x275 in High Divergence Mode
+! See CDR Table 3.3
+
+Main:numberOfEvents = 1000000
+
+
+! Beam Parameters
+
+Beams:frameType = 2
+Beams:idA = 2212
+Beams:idB = 11
+
+Beams:eA = 275
+Beams:eB = 9
+
+Beams:allowMomentumSpread = on
+Beams:sigmapxA = 0.000119
+Beams:sigmapyA = 0.000119
+Beams:sigmapzA = 0.00068
+
+Beams:sigmapxB = 0.000211
+Beams:sigmapyB = 0.000152
+Beams:sigmapzB = 0.00058
+
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 0.067
+Beams:sigmaVertexY = 0.006
+Beams:sigmaVertexZ = 0.0
+
+
+! PDF Selection 2 = CTEQ5L
+! PDF:GammaHardSet needed to try SAS Photon set, LHAPDF5 isn't linked yet ...
+! PDF:extrapolate = on allow extrapolations to low x 
+PDF:pset = 2
+PDF:lepton = off
+
+
+! Subprocess Selection
+WeakBosonExchange:ff2ff(t:gmZ) = on
+
+
+! Shower Settings
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+TimeShower:QEDshowerByL = off
+
+
+! Photoproduction Settings and Kinematics
+! 0 = All
+! 1 = Resolved
+! 2 = Direct
+
+
+! PhaseSpace Settings
+!
+! PhaseSpace:pTHatMin = 1.0
+! PhaseSpace:pTHatMinDiverge = 0.5
+PhaseSpace:mHatMin = 0.0
+PhaseSpace:pTHatMinDiverge = force 0.01
+PhaseSpace:Q2Min = 1.0
+PhaseSpace:Q2Max = 10.0
+
+
+! Hadronization and Radiation Settings
+HadronLevel:Decay = on
+HadronLevel:all = on
+PartonLevel:ISR = on
+PartonLevel:MPI = off
+PartonLevel:FSR = on
+PromptPhoton:all = off
+
+
+! Display Settings
+Init:showProcesses = off
+Init:showChangedSettings = off
+Init:showMultipartonInteractions = off
+Init:showChangedParticleData = off
+
+Next:numberShowInfo = 0
+Next:numberShowProcess = 0
+Next:numberShowEvent = 0
+Next:numberCount = 10000
+
+Random:setSeed = on
+Random:seed = 0


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

I have modified the Pythia8 beam effects code to accept beam energy combinations for the early science simulations. I have also added high divergence steering files for 3 exclusive Q2 bins (1-10, 10-100, and 100-1000) for the energies 18x275, 10x275, 10x100, 5x100, 5x41, 10x250, 10x130, 9x275, and 9x130. The last 4 energy combinations are new for early science. As new machine simulations do not exist, 10x250 and 9x275 are copies of the parameters from 10x275 while 10x130 and 9x130 are copies of the parameters from 10x100.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
